### PR TITLE
Add lock wait feature and custom exceptions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: ruby
 script: bundle exec rspec
 rvm:
-  - "1.8.7"
-  - "1.9.3"
-  - "1.9.2"
-  - "2.0.0"
+  - "1.8"
+  - "1.9"
+  - "2.0"
+  - "2.1"
+  - "2.2"
+  - "2.3"
   - jruby-19mode
   - jruby-18mode
   - rbx-2.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+before_install:
+  - gem update bundler
 language: ruby
 script: bundle exec rspec
 rvm:
@@ -6,7 +8,7 @@ rvm:
   - "2.0"
   - "2.1"
   - "2.2"
-  - "2.3"
+  - "2.3.0"
   - jruby-19mode
   - jruby-18mode
-  - rbx-2.2
+  - rbx-2

--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ Filelock '/tmp/path/to/lock', :timeout => 10 do
 end
 ```
 
+You can also pass a wait timeout for grabbing the lock (default is 60 seconds):
+
+```ruby
+Filelock '/tmp/path/to/lock', :wait => 10 do
+  # do blocking operation
+end
+```
+
 Note that lock file directory must already exist, and lock file is not removed after unlock.
 
 ## FAQ

--- a/filelock.gemspec
+++ b/filelock.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler", "> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
 end

--- a/lib/filelock.rb
+++ b/lib/filelock.rb
@@ -1,4 +1,6 @@
 require 'filelock/version'
+require 'filelock/exec_timeout'
+require 'filelock/wait_timeout'
 require 'timeout'
 require 'tempfile'
 
@@ -6,16 +8,16 @@ if RUBY_PLATFORM == "java"
   def Filelock(lockname, options = {}, &block)
     lockname = lockname.path if lockname.is_a?(Tempfile)
     File.open(lockname, File::RDWR|File::CREAT, 0644) do |file|
-      Thread.pass until file.flock(File::LOCK_EX)
-      Timeout::timeout(options.fetch(:timeout, 60)) { yield }
+      Thread.pass until Timeout::timeout(options.fetch(:wait, 60), Filelock::WaitTimeout) { file.flock(File::LOCK_EX) }
+      Timeout::timeout(options.fetch(:timeout, 60), Filelock::ExecTimeout) { yield }
     end
   end
 else
   def Filelock(lockname, options = {}, &block)
     lockname = lockname.path if lockname.is_a?(Tempfile)
     File.open(lockname, File::RDWR|File::CREAT, 0644) do |file|
-      file.flock(File::LOCK_EX)
-      Timeout::timeout(options.fetch(:timeout, 60)) { yield }
+      Timeout::timeout(options.fetch(:wait, 60), Filelock::WaitTimeout) { file.flock(File::LOCK_EX) }
+      Timeout::timeout(options.fetch(:timeout, 60), Filelock::ExecTimeout) { yield }
     end
   end
 end

--- a/lib/filelock/exec_timeout.rb
+++ b/lib/filelock/exec_timeout.rb
@@ -1,0 +1,7 @@
+module Filelock
+  class ExecTimeout < Timeout::Error
+      def message
+        "Didn't finish executing Filelock block within the timeout specified."
+      end
+  end
+end

--- a/lib/filelock/wait_timeout.rb
+++ b/lib/filelock/wait_timeout.rb
@@ -1,0 +1,7 @@
+module Filelock
+  class WaitTimeout < Timeout::Error
+      def message
+        "Unable to acquire a file lock within the wait timeout specified."
+      end
+  end
+end


### PR DESCRIPTION
I needed the option for a lock wait timeout, similar to flock. I also thought there should be some custom exceptions for Filelock with decent descriptions so when using the library within your app, it's obvious what's causing the issue.