### PR TITLE
Add missing require for pathname

### DIFF
--- a/spec/filelock_spec.rb
+++ b/spec/filelock_spec.rb
@@ -1,4 +1,5 @@
 require 'filelock'
+require 'pathname'
 require 'tempfile'
 require 'timeout'
 


### PR DESCRIPTION
Fixes the following error on Ruby 3 here:

```
.............F..

Failures:

  1) Filelock should handle Pathname as well as string path
     Failure/Error: lockpath = Pathname.new(File.join(dir, 'sample.lock'))

     NameError:
       uninitialized constant Pathname
     # ./spec/filelock_spec.rb:254:in `block (3 levels) in <top (required)>'
     # ./spec/filelock_spec.rb:253:in `block (2 levels) in <top (required)>'

Finished in 8.35 seconds (files took 0.05113 seconds to load)
16 examples, 1 failure

Failed examples:

rspec ./spec/filelock_spec.rb:252 # Filelock should handle Pathname as well as string path
```